### PR TITLE
Add Nix-based Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ COPY hexstrike-ai-mcp.json ./
 COPY assets ./assets
 COPY README.md ./
 
-RUN nix --extra-experimental-features "nix-command flakes" --impure profile install .#hexstrike-ai-server \
-    && nix --extra-experimental-features "nix-command flakes" --impure profile install .#hexstrike-ai-mcp \
-    && nix --extra-experimental-features "nix-command flakes" --impure profile install nixpkgs#bashInteractive \
+RUN nix --extra-experimental-features "nix-command flakes" profile install --impure .#hexstrike-ai-server \
+    && nix --extra-experimental-features "nix-command flakes" profile install --impure .#hexstrike-ai-mcp \
+    && nix --extra-experimental-features "nix-command flakes" profile install --impure nixpkgs#bashInteractive \
     && rm -rf /root/.cache/nix
 
 # Provide a writable workspace for scan outputs and reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,16 @@ COPY hexstrike-ai-mcp.json ./
 COPY assets ./assets
 COPY README.md ./
 
-RUN nix --extra-experimental-features "nix-command flakes" profile install .#hexstrike-ai-server \
-    && nix --extra-experimental-features "nix-command flakes" profile install .#hexstrike-ai-mcp \
-    && nix --extra-experimental-features "nix-command flakes" profile install nixpkgs#bashInteractive \
+RUN nix --extra-experimental-features "nix-command flakes" --impure profile install .#hexstrike-ai-server \
+    && nix --extra-experimental-features "nix-command flakes" --impure profile install .#hexstrike-ai-mcp \
+    && nix --extra-experimental-features "nix-command flakes" --impure profile install nixpkgs#bashInteractive \
     && rm -rf /root/.cache/nix
 
 # Provide a writable workspace for scan outputs and reports
 RUN mkdir -p /workspace
 WORKDIR /workspace
 
-ENV PATH=/nix/var/nix/profiles/default/bin:$PATH \
+ENV PATH=/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH \
     HEXSTRIKE_HOST=0.0.0.0 \
     HEXSTRIKE_PORT=8888
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+FROM nixos/nix:2.21.2
+
+ENV NIX_CONFIG "experimental-features = nix-command flakes"
+ENV NIXPKGS_ALLOW_UNFREE=1
+
+WORKDIR /opt/hexstrike
+
+COPY flake.nix ./
+COPY requirements.txt ./
+COPY hexstrike_server.py ./
+COPY hexstrike_mcp.py ./
+COPY hexstrike-ai-mcp.json ./
+COPY assets ./assets
+COPY README.md ./
+
+RUN nix --extra-experimental-features "nix-command flakes" profile install .#hexstrike-ai-server \
+    && nix --extra-experimental-features "nix-command flakes" profile install .#hexstrike-ai-mcp \
+    && nix --extra-experimental-features "nix-command flakes" profile install nixpkgs#bashInteractive \
+    && rm -rf /root/.cache/nix
+
+# Provide a writable workspace for scan outputs and reports
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+ENV PATH=/nix/var/nix/profiles/default/bin:$PATH \
+    HEXSTRIKE_HOST=0.0.0.0 \
+    HEXSTRIKE_PORT=8888
+
+EXPOSE 8888
+
+ENTRYPOINT ["hexstrike_server.py"]
+CMD ["--port", "8888"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+
+services:
+  hexstrike:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: hexstrike-ai:latest
+    container_name: hexstrike-ai
+    user: "0:0"
+    privileged: true
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    environment:
+      HEXSTRIKE_HOST: "0.0.0.0"
+      HEXSTRIKE_PORT: "8888"
+    ports:
+      - "8888:8888"
+    volumes:
+      - ./data:/workspace/data
+    stdin_open: true
+    tty: true
+    restart: unless-stopped

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,242 @@
+{
+  description = "HexStrike AI Nix flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    pyproject-nix = {
+      url = "github:nix-community/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    autorecon-src = {
+      url = "github:Tib3rius/AutoRecon";
+      flake = false;
+    };
+    paramspider-src = {
+      url = "github:devanshbatham/ParamSpider/790eb91213419e9c4ddec2c91201d4be5399cb77";
+      flake = false;
+    };
+    scout-suite-src = {
+      url = "github:nccgroup/ScoutSuite/7909f2fc6186063e5c9e7ddef8c4d7d1072c8f3d";
+      flake = false;
+    };
+    docker-bench-security-src = {
+      url = "github:docker/docker-bench-security";
+      flake = false;
+    };
+  };
+
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      flake-utils,
+      pyproject-nix,
+      autorecon-src,
+      paramspider-src,
+      scout-suite-src,
+      docker-bench-security-src,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        # webdriver-manager (in requirements.txt) in nixpkgs has a platforms definition that excludes darwin
+        # we drop this along with linux-specific tests with this overlay
+        overlayWebdriverManager = (final: prev: {
+          python3 = prev.python3.override {
+            packageOverrides = self: super: {
+              "webdriver-manager" =
+                super."webdriver-manager".overridePythonAttrs (old: {
+                  # Allow on macOS (remove the platforms restriction)
+                  meta = builtins.removeAttrs old.meta [ "platforms" ];
+
+                  # Skip tests and avoid test deps (prevents pybrowsers/mdfind path)
+                  doCheck = false;
+                  nativeCheckInputs = [ ];
+                  checkInputs = [ ];
+                  checkPhase = "true";
+                  pythonImportsCheck = [ ];
+                });
+            };
+          };
+
+          # expose the updated package set so anything using pkgs.python3Packages sees it
+          python3Packages = final.python3.pkgs;
+        });
+
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+          };
+          overlays = [ overlayWebdriverManager ];
+        };
+
+        python = pkgs.python3;
+        pythonPackages = pkgs.python3Packages;
+
+        # Below are dependencies not packaged in nixpkgs
+        #autorecon-project = pyproject-nix.lib.project.loadPyproject { projectRoot = autorecon-src; };
+        #ar-attrs = autorecon-project.renderers.buildPythonPackage { inherit python; };
+        #autorecon = python.pkgs.buildPythonApplication (ar-attrs // {
+        #  name = "autorecon";
+        #});
+
+        #paramspider = python.pkgs.buildPythonApplication {
+        #  name = "paramspider";
+        #  version = "790eb91";
+
+        #  src = paramspider-src;
+        #};
+
+        #scout-suite = python.pkgs.buildPythonApplication {
+        #  name = "scout-suite";
+        #  version = "7909f2f";
+
+        #  src = scout-suite-src;
+        #};
+
+        docker-bench-security = pkgs.stdenv.mkDerivation {
+          name = "docker-bench-security";
+          builder = pkgs.bash;
+          buildInputs = [ pkgs.jq ];
+          args = let
+            buildScript = pkgs.writeShellScript "build" ''
+              ${pkgs.coreutils}/bin/mkdir -p $out/bin
+              ${pkgs.coreutils}/bin/cp ${docker-bench-security-src}/docker-bench-security.sh $out/bin/docker-bench-security.sh
+            '';
+          in [ buildScript ];
+        };
+        # End of custom packages
+
+        corepkgs = with pkgs; [
+          # Network & Reconnaissance
+          nmap
+          masscan
+          rustscan
+          amass
+          subfinder
+          nuclei
+          fierce
+          dnsenum
+          aircrack-ng
+          metasploit
+          #autorecon # TODO
+          responder
+          enum4linux-ng
+          theharvester
+          # Web Application Security
+          gobuster
+          feroxbuster
+          pythonPackages.dirsearch
+          ffuf
+          dirb
+          httpx
+          katana
+          nikto
+          sqlmap
+          wpscan
+          arjun
+          ##paramspider # TODO
+          dalfox
+          wafw00f
+          # Password & Authentication
+          john
+          hashcat
+          medusa
+          ##pythonPackages.patator # TODO: marked broken in nixpkgs
+          evil-winrm
+          hash-identifier
+          # Binary Analysis & Reverse Engineering
+          gdb
+          radare2
+          binwalk
+          ghidra-bin
+          binutils
+          volatility3
+          foremost
+          steghide
+          exiftool
+          # Cloud Security Tools
+          ##prowler # TODO broken in nixpkgs
+          trivy
+          ##scout-suite # TODO
+          kube-hunter
+          kube-bench
+          docker-bench-security
+        ] ++ lib.optionals pkgs.stdenv.isLinux [
+          # Linux specific tooling
+          # Network & Reconnaissance
+          netexec
+          # Web Application Security
+          # Password & Authentication
+          hydra
+          ophcrack
+          # Binary Analysis & Reverse Engineering
+          checksec
+          u-root-cmds
+          # Browser Agent Requirements
+          chromium
+          chromedriver
+        ] ++ lib.optionals pkgs.stdenv.isDarwin [
+          # macOS specific tooling
+          # Browser Agent Requirements
+          google-chrome
+        ];
+
+        hexstrike-ai-project = pyproject-nix.lib.project.loadRequirementsTxt {
+          projectRoot = ./.;
+        };
+        hexstrike-attrs = hexstrike-ai-project.renderers.buildPythonPackage { inherit python; };
+        hexstrike-ai-server-pkg = python.pkgs.buildPythonApplication (hexstrike-attrs // {
+          name = "hexstrike-ai-server";
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/bin
+            cp ${self}/hexstrike_server.py $out/bin/hexstrike_server.py
+            chmod +x $out/bin/hexstrike_server.py
+
+            wrapProgram $out/bin/hexstrike_server.py \
+              --prefix PATH : ${pkgs.lib.makeBinPath corepkgs}
+
+            runHook postInstall
+          '';
+          meta = {
+            mainProgram = "hexstrike_server.py";
+          };
+        });
+
+        hexstrike-ai-mcp-pkg = python.pkgs.buildPythonApplication (hexstrike-attrs // {
+          name = "hexstrike-ai-mcp";
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/bin
+            cp ${self}/hexstrike_mcp.py $out/bin/hexstrike_mcp.py
+            chmod +x $out/bin/hexstrike_mcp.py
+            runHook postInstall
+          '';
+          meta = {
+            mainProgram = "hexstrike_mcp.py";
+          };
+        });
+
+      in
+      {
+        devShell = pkgs.mkShell {
+          name = "HexStrike AI Dev Shell";
+          buildInputs = [ hexstrike-ai-server-pkg hexstrike-ai-mcp-pkg ];
+        };
+
+        packages = rec {
+          hexstrike-ai-server = hexstrike-ai-server-pkg;
+          hexstrike-ai-mcp = hexstrike-ai-mcp-pkg;
+          default = hexstrike-ai-server;
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -191,10 +191,13 @@
           hexstrike-ai-project.renderers.buildPythonPackage {
             inherit python;
             format = "other";
-            dontBuild = true;
           };
         hexstrike-ai-server-pkg = python.pkgs.buildPythonApplication (hexstrike-attrs // {
           name = "hexstrike-ai-server";
+          buildPhase = ''
+            runHook preBuild
+            runHook postBuild
+          '';
           nativeBuildInputs = [ pkgs.makeWrapper ];
           installPhase = ''
             runHook preInstall
@@ -215,6 +218,10 @@
 
         hexstrike-ai-mcp-pkg = python.pkgs.buildPythonApplication (hexstrike-attrs // {
           name = "hexstrike-ai-mcp";
+          buildPhase = ''
+            runHook preBuild
+            runHook postBuild
+          '';
           installPhase = ''
             runHook preInstall
 

--- a/flake.nix
+++ b/flake.nix
@@ -188,11 +188,14 @@
           projectRoot = ./.;
         };
         hexstrike-attrs =
-          hexstrike-ai-project.renderers.buildPythonPackage {
-            inherit python;
-            pyproject = null;
-            format = "other";
-          };
+          let
+            rendered = hexstrike-ai-project.renderers.buildPythonPackage {
+              inherit python;
+              pyproject = null;
+              format = "other";
+            };
+          in
+          builtins.removeAttrs rendered [ "pyproject" "format" ];
         hexstrike-ai-server-pkg = python.pkgs.buildPythonApplication (hexstrike-attrs // {
           name = "hexstrike-ai-server";
           buildPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -190,6 +190,7 @@
         hexstrike-attrs =
           hexstrike-ai-project.renderers.buildPythonPackage {
             inherit python;
+            pyproject = null;
             format = "other";
           };
         hexstrike-ai-server-pkg = python.pkgs.buildPythonApplication (hexstrike-attrs // {

--- a/flake.nix
+++ b/flake.nix
@@ -187,7 +187,12 @@
         hexstrike-ai-project = pyproject-nix.lib.project.loadRequirementsTxt {
           projectRoot = ./.;
         };
-        hexstrike-attrs = hexstrike-ai-project.renderers.buildPythonPackage { inherit python; };
+        hexstrike-attrs =
+          hexstrike-ai-project.renderers.buildPythonPackage {
+            inherit python;
+            format = "other";
+            dontBuild = true;
+          };
         hexstrike-ai-server-pkg = python.pkgs.buildPythonApplication (hexstrike-attrs // {
           name = "hexstrike-ai-server";
           nativeBuildInputs = [ pkgs.makeWrapper ];


### PR DESCRIPTION
## Summary
- add a flake that packages the HexStrike AI server and MCP client with the full security toolchain
- add a Nix-enabled Dockerfile that installs the packaged applications and exposes the API server
- provide a docker-compose definition that runs the container as root with the required capabilities

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce9b1bc27483338e4df69575a3b50e